### PR TITLE
Add minimal AR.js camera webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AR.js Minimal Camera View</title>
+    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@1c2407b26c61958baa93967b5412487cd94b290b/dist/aframe-master.min.js"></script>
+    <script src="https://raw.githack.com/AR-js-org/AR.js/master/aframe/build/aframe-ar-nft.js"></script>
+  </head>
+  <body style="margin: 0; overflow: hidden;">
+    <a-scene embedded arjs="sourceType: webcam;">
+      <a-entity camera></a-entity>
+    </a-scene>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal HTML page that loads A-Frame and AR.js
- show only the webcam feed with a basic camera entity in the AR scene

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e0a499ee088326b87daf7be42ab1ce