### PR TITLE
Display cube on HIRO marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AR.js Minimal Camera View</title>
+    <title>HIRO Marker Cube</title>
     <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@1c2407b26c61958baa93967b5412487cd94b290b/dist/aframe-master.min.js"></script>
     <script src="https://raw.githack.com/AR-js-org/AR.js/master/aframe/build/aframe-ar-nft.js"></script>
   </head>
   <body style="margin: 0; overflow: hidden;">
     <a-scene embedded arjs="sourceType: webcam;">
+      <a-marker preset="hiro">
+        <a-box position="0 0.5 0" geometry="primitive: box; width: 1; height: 1; depth: 1"></a-box>
+      </a-marker>
       <a-entity camera></a-entity>
     </a-scene>
   </body>


### PR DESCRIPTION
## Summary
- add a HIRO preset marker to the AR scene
- render a unit cube positioned to sit on the detected marker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a9860c7c8326bed2bcb138c9a53d