### PR TITLE
Replace cube marker model with Unity-Chan FBX

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>HIRO Marker Cube</title>
+    <title>HIRO Marker Unity-Chan</title>
     <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@1c2407b26c61958baa93967b5412487cd94b290b/dist/aframe-master.min.js"></script>
     <script src="https://raw.githack.com/AR-js-org/AR.js/master/aframe/build/aframe-ar-nft.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@v6.1.1/dist/aframe-extras.loaders.min.js"></script>
   </head>
   <body style="margin: 0; overflow: hidden;">
     <a-scene embedded arjs="sourceType: webcam;">
+      <a-assets>
+        <a-asset-item id="unitychan" src="unitychan.fbx"></a-asset-item>
+      </a-assets>
       <a-marker preset="hiro">
-        <a-box position="0 0.5 0" geometry="primitive: box; width: 1; height: 1; depth: 1"></a-box>
+        <a-entity
+          fbx-model="src: #unitychan"
+          position="0 0 0"
+          rotation="0 180 0"
+          scale="0.01 0.01 0.01"
+        ></a-entity>
       </a-marker>
       <a-entity camera></a-entity>
     </a-scene>


### PR DESCRIPTION
## Summary
- render the Unity-Chan FBX model on the HIRO marker instead of the placeholder cube
- add the aframe-extras loader and preload the FBX asset for use in the scene
- restore the original two-space indentation in the document head block

## Testing
- not run (web scene change)


------
https://chatgpt.com/codex/tasks/task_e_68e0bb99720483268b71b42e2e6058b8