### PR TITLE
Enable audio-controlled animation playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,11 @@
     </a-scene>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-        const sceneEl = document.querySelector("a-scene");
         const modelEl = document.querySelector("#cesium-entity");
-        let isPlaying = true;
+        const THRESHOLD = 0.05;
+        let isPlaying = false;
 
-        const toggleAnimation = () => {
+        const updateAnimationState = (shouldPlay) => {
           if (!modelEl) {
             return;
           }
@@ -44,11 +44,78 @@
             return;
           }
 
-          mixerComponent.mixer.timeScale = isPlaying ? 0 : 1;
-          isPlaying = !isPlaying;
+          if (isPlaying === shouldPlay) {
+            return;
+          }
+
+          mixerComponent.mixer.timeScale = shouldPlay ? 1 : 0;
+          isPlaying = shouldPlay;
         };
 
-        sceneEl.addEventListener("click", toggleAnimation);
+        const monitorAudio = async () => {
+          try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            const source = audioContext.createMediaStreamSource(stream);
+            const analyser = audioContext.createAnalyser();
+            analyser.fftSize = 2048;
+            const dataArray = new Uint8Array(analyser.fftSize);
+            source.connect(analyser);
+
+            const analyse = () => {
+              analyser.getByteTimeDomainData(dataArray);
+              let sum = 0;
+              for (let i = 0; i < dataArray.length; i += 1) {
+                const value = (dataArray[i] - 128) / 128;
+                sum += value * value;
+              }
+              const rms = Math.sqrt(sum / dataArray.length);
+              updateAnimationState(rms > THRESHOLD);
+              requestAnimationFrame(analyse);
+            };
+
+            analyse();
+          } catch (error) {
+            console.error("マイクの取得に失敗しました", error);
+          }
+        };
+
+        const initialize = () => {
+          updateAnimationState(false);
+          monitorAudio();
+
+          const SpeechRecognition =
+            window.SpeechRecognition || window.webkitSpeechRecognition;
+          if (SpeechRecognition) {
+            try {
+              const recognition = new SpeechRecognition();
+              recognition.continuous = true;
+              recognition.interimResults = true;
+              recognition.onresult = () => {};
+              recognition.onerror = (event) => {
+                console.error("音声認識エラー", event.error);
+              };
+              recognition.onend = () => {
+                try {
+                  recognition.start();
+                } catch (error) {
+                  console.error("音声認識の再開に失敗しました", error);
+                }
+              };
+              recognition.start();
+            } catch (error) {
+              console.error("音声認識の開始に失敗しました", error);
+            }
+          } else {
+            console.warn("このブラウザはWeb Speech APIに対応していません");
+          }
+        };
+
+        if (modelEl.hasLoaded) {
+          initialize();
+        } else {
+          modelEl.addEventListener("model-loaded", initialize, { once: true });
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- replace the click-based animation toggle with microphone-driven control
- add Web Speech API initialization and audio level monitoring to start and stop the animation automatically

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e23e4bb824832693aea3987bc4f286