### PR TITLE
Stop auto-playing Cesium model animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         <a-entity
           id="cesium-entity"
           gltf-model="#buddymodel"
-          animation-mixer=""
+          animation-mixer="timeScale: 0"
           position="0 0 0"
           rotation="0 0 0"
           scale="1 1 1"


### PR DESCRIPTION
## Summary
- prevent the Cesium model animation from auto-playing by default
- keep audio-driven animation control logic intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23f8d6d8483269cc8ad268da6d373