### PR TITLE
Add greeting response after user speech

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
     <script>
       document.addEventListener("DOMContentLoaded", () => {
         const modelEl = document.querySelector("#cesium-entity");
-        const THRESHOLD = 0.05;
         let isPlaying = false;
 
         const updateAnimationState = (shouldPlay) => {
@@ -52,38 +51,8 @@
           isPlaying = shouldPlay;
         };
 
-        const monitorAudio = async () => {
-          try {
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            const source = audioContext.createMediaStreamSource(stream);
-            const analyser = audioContext.createAnalyser();
-            analyser.fftSize = 2048;
-            const dataArray = new Uint8Array(analyser.fftSize);
-            source.connect(analyser);
-
-            const analyse = () => {
-              analyser.getByteTimeDomainData(dataArray);
-              let sum = 0;
-              for (let i = 0; i < dataArray.length; i += 1) {
-                const value = (dataArray[i] - 128) / 128;
-                sum += value * value;
-              }
-              const rms = Math.sqrt(sum / dataArray.length);
-              updateAnimationState(rms > THRESHOLD);
-              requestAnimationFrame(analyse);
-            };
-
-            analyse();
-          } catch (error) {
-            console.error("マイクの取得に失敗しました", error);
-          }
-        };
-
         const initialize = () => {
           updateAnimationState(false);
-          monitorAudio();
-
           const SpeechRecognition =
             window.SpeechRecognition || window.webkitSpeechRecognition;
           if (SpeechRecognition) {
@@ -91,7 +60,44 @@
               const recognition = new SpeechRecognition();
               recognition.continuous = true;
               recognition.interimResults = true;
-              recognition.onresult = () => {};
+              let speakTimeoutId = null;
+              const triggerGreeting = () => {
+                speakTimeoutId = null;
+                if (!window.speechSynthesis) {
+                  console.warn("このブラウザは音声合成に対応していません");
+                  return;
+                }
+
+                window.speechSynthesis.cancel();
+                const utterance = new SpeechSynthesisUtterance("こんにちはマスター");
+                utterance.lang = "ja-JP";
+                utterance.onstart = () => {
+                  updateAnimationState(true);
+                };
+                const stopAnimation = () => {
+                  updateAnimationState(false);
+                };
+                utterance.onend = stopAnimation;
+                utterance.onerror = stopAnimation;
+                window.speechSynthesis.speak(utterance);
+              };
+
+              recognition.onresult = (event) => {
+                const { results } = event;
+                if (!results || results.length === 0) {
+                  return;
+                }
+
+                const latestResult = results[results.length - 1];
+                if (!latestResult.isFinal) {
+                  return;
+                }
+
+                if (speakTimeoutId) {
+                  clearTimeout(speakTimeoutId);
+                }
+                speakTimeoutId = setTimeout(triggerGreeting, 500);
+              };
               recognition.onerror = (event) => {
                 console.error("音声認識エラー", event.error);
               };


### PR DESCRIPTION
## Summary
- replace RMS-based microphone animation with a SpeechRecognition-driven flow
- speak "こんにちはマスター" 0.5 seconds after a final recognition result and animate while speaking
- ensure animation stops when speech synthesis finishes

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e247ed87d08326bbe6c5594bfb865b